### PR TITLE
 Remove the PNO verion bit from the update scan param response to get the correcly response status

### DIFF
--- a/smd.c
+++ b/smd.c
@@ -140,6 +140,7 @@ int wcn36xx_smd_start(struct wcn36xx *wcn)
 
 	return wcn36xx_smd_send_and_wait(wcn, msg_body.header.len);
 }
+
 static int wcn36xx_smd_start_rsp(struct wcn36xx *wcn, void *buf, size_t len)
 {
 	struct wcn36xx_hal_mac_start_rsp_msg * rsp;
@@ -300,14 +301,17 @@ int wcn36xx_smd_update_scan_params(struct wcn36xx *wcn){
 }
 static int wcn36xx_smd_update_scan_params_rsp(void *buf, size_t len)
 {
-	struct  wcn36xx_hal_update_scan_params_resp * rsp;
+	struct wcn36xx_hal_update_scan_params_resp *rsp;
 
 	rsp = (struct wcn36xx_hal_update_scan_params_resp *)buf;
 
-	wcn36xx_dbg(WCN36XX_DBG_HAL,
-		    "hal rsp update scan params status %d",
-		    rsp->status);
+	/* Remove the PNO version bit */
+	rsp->status &= (~(WCN36XX_FW_MSG_PNO_VERSION_MASK));
 
+	if (WCN36XX_FW_MSG_RESULT_SUCCESS != rsp->status) {
+		wcn36xx_warn("error response from update scan");
+		return -EIO;
+	}
 	return 0;
 }
 

--- a/smd.h
+++ b/smd.h
@@ -27,6 +27,8 @@
 #define SMD_MSG_TIMEOUT 200
 #define WCN36XX_SMSM_WLAN_TX_ENABLE	 		0x00000400
 #define WCN36XX_SMSM_WLAN_TX_RINGS_EMPTY		0x00000200
+/* The PNO version info be contained in the rsp msg */
+#define WCN36XX_FW_MSG_PNO_VERSION_MASK			0x8000
 
 enum wcn36xx_fw_msg_result {
 	WCN36XX_FW_MSG_RESULT_SUCCESS			= 0,


### PR DESCRIPTION
Remove the PNO verion bit from the update scan param response to get the correcly response status

Signed-off-by: Yanbo Li yanbol@qti.qualcomm.com
