### PR TITLE
Enable different bd_rates for different packet types

### DIFF
--- a/dxe.c
+++ b/dxe.c
@@ -20,6 +20,7 @@
  * through high channels managment packets are transfered
  */
 #include <linux/interrupt.h>
+#include <linux/ieee80211.h>
 #include "dxe.h"
 #include "txrx.h"
 #include "wcn36xx.h"
@@ -483,6 +484,7 @@ int wcn36xx_dxe_tx(struct wcn36xx *wcn,
 	struct wcn36xx_dxe_ctl *ctl = NULL;
 	struct wcn36xx_dxe_desc *desc = NULL;
 	struct wcn36xx_dxe_ch *ch = NULL;
+	struct ieee80211_hdr *hdr = (struct ieee80211_hdr *)skb->data;
 
 	ch = is_high ? &wcn->dxe_tx_h_ch : &wcn->dxe_tx_l_ch;
 
@@ -503,9 +505,9 @@ int wcn36xx_dxe_tx(struct wcn36xx *wcn,
 	wcn36xx_prepare_tx_bd(ctl->bd_cpu_addr, skb->len, header_len);
 	if (!is_high && WCN36XX_BSS_KEY == wcn->en_state) {
 		wcn36xx_dbg(WCN36XX_DBG_DXE, "DXE Encription enabled");
-		wcn36xx_fill_tx_bd(wcn, ctl->bd_cpu_addr, broadcast, 0);
+		wcn36xx_fill_tx_bd(wcn, ctl->bd_cpu_addr, broadcast, 0, hdr);
 	} else {
-		wcn36xx_fill_tx_bd(wcn, ctl->bd_cpu_addr, broadcast, 1);
+		wcn36xx_fill_tx_bd(wcn, ctl->bd_cpu_addr, broadcast, 1, hdr);
 	}
 
 	ctl = ch->head_blk_ctl;

--- a/txrx.h
+++ b/txrx.h
@@ -27,6 +27,11 @@
 /* broadcast wq ID */
 #define WCN36XX_TX_B_WQ_ID		0xA
 #define WCN36XX_TX_U_WQ_ID		0x9
+/* bd_rate */
+#define WCN36XX_BD_RATE_DATA 0
+#define WCN36XX_BD_RATE_MGMT 2
+#define WCN36XX_BD_RATE_CTRL 3
+
 struct wcn36xx_pdu {
 	u32	dpu_fb:8;
 	u32	adu_fb:8;
@@ -146,5 +151,5 @@ struct wcn36xx_tx_bd {
 int  wcn36xx_rx_skb(struct wcn36xx *wcn, struct sk_buff *skb);
 void wcn36xx_prepare_tx_bd(struct wcn36xx_tx_bd *bd, u32 len, u32 header_len);
 void wcn36xx_fill_tx_bd(struct wcn36xx *wcn, struct wcn36xx_tx_bd *bd,
-			u8 broadcast, u8 encrypt);
+			u8 broadcast, u8 encrypt, struct ieee80211_hdr *hdr);
 #endif	/* _TXRX_H_ */


### PR DESCRIPTION
This commit enable Auto TX Rate adaption for standard ofdm/dsss rates.

Signed-off-by: Olof Johansson dev@skyshaper.net
