### PR TITLE
Adapt to AP rates and enable n-rates

### DIFF
--- a/hal.h
+++ b/hal.h
@@ -454,10 +454,10 @@ enum sta_rate_mode {
 };
 
 /* 1,2,5.5,11 */
-#define WCN36XX_HAL_NUM_11B_RATES           4
+#define WCN36XX_HAL_NUM_DSSS_RATES           4
 
 /* 6,9,12,18,24,36,48,54 */
-#define WCN36XX_HAL_NUM_11A_RATES           8
+#define WCN36XX_HAL_NUM_OFDM_RATES           8
 
 /* 72,96,108 */
 #define WCN36XX_HAL_NUM_POLARIS_RATES       3
@@ -1026,8 +1026,8 @@ struct wcn36xx_hal_supported_rates {
 
 	/* 11b, 11a and aniLegacyRates are IE rates which gives rate in
 	 * unit of 500Kbps */
-	u16 llb_rates[WCN36XX_HAL_NUM_11B_RATES];
-	u16 lla_rates[WCN36XX_HAL_NUM_11A_RATES];
+	u16 dsss_rates[WCN36XX_HAL_NUM_DSSS_RATES];
+	u16 ofdm_rates[WCN36XX_HAL_NUM_OFDM_RATES];
 	u16 legacy_rates[WCN36XX_HAL_NUM_POLARIS_RATES];
 	u16 reserved;
 

--- a/main.c
+++ b/main.c
@@ -780,19 +780,19 @@ static int __init wcn36xx_init(void)
 
 	/* Configuring supported rates */
 	wcn->supported_rates.op_rate_mode = STA_11n;
-	wcn->supported_rates.llb_rates[0] = 0x82;
-	wcn->supported_rates.llb_rates[1] = 0x84;
-	wcn->supported_rates.llb_rates[2] = 0x8b;
-	wcn->supported_rates.llb_rates[3] = 0x96;
+	wcn->supported_rates.dsss_rates[0] = 0x82;
+	wcn->supported_rates.dsss_rates[1] = 0x84;
+	wcn->supported_rates.dsss_rates[2] = 0x8b;
+	wcn->supported_rates.dsss_rates[3] = 0x96;
 
-	wcn->supported_rates.lla_rates[0] = 0x0C;
-	wcn->supported_rates.lla_rates[1] = 0x12;
-	wcn->supported_rates.lla_rates[2] = 0x18;
-	wcn->supported_rates.lla_rates[3] = 0x24;
-	wcn->supported_rates.lla_rates[4] = 0x30;
-	wcn->supported_rates.lla_rates[5] = 0x48;
-	wcn->supported_rates.lla_rates[6] = 0x60;
-	wcn->supported_rates.lla_rates[7] = 0x6C;
+	wcn->supported_rates.ofdm_rates[0] = 0x0C;
+	wcn->supported_rates.ofdm_rates[1] = 0x12;
+	wcn->supported_rates.ofdm_rates[2] = 0x18;
+	wcn->supported_rates.ofdm_rates[3] = 0x24;
+	wcn->supported_rates.ofdm_rates[4] = 0x30;
+	wcn->supported_rates.ofdm_rates[5] = 0x48;
+	wcn->supported_rates.ofdm_rates[6] = 0x60;
+	wcn->supported_rates.ofdm_rates[7] = 0x6C;
 
 	wcn->supported_rates.supported_mcs_set[0] = 0xFF;
 

--- a/main.c
+++ b/main.c
@@ -101,7 +101,7 @@ static struct ieee80211_channel wcn_5ghz_channels[] = {
 	.hw_value_short = (_hw_rate)  \
 }
 
-static struct ieee80211_rate wcn_legacy_rates[] = {
+static struct ieee80211_rate wcn_2ghz_rates[] = {
 	RATE(10, 0x02, 0),
 	RATE(20, 0x04, IEEE80211_RATE_SHORT_PREAMBLE),
 	RATE(55, 0x0B, IEEE80211_RATE_SHORT_PREAMBLE),
@@ -130,8 +130,8 @@ static struct ieee80211_rate wcn_5ghz_rates[] = {
 static struct ieee80211_supported_band wcn_band_2ghz = {
 	.channels	= wcn_2ghz_channels,
 	.n_channels	= ARRAY_SIZE(wcn_2ghz_channels),
-	.bitrates	= wcn_legacy_rates,
-	.n_bitrates	= ARRAY_SIZE(wcn_legacy_rates),
+	.bitrates	= wcn_2ghz_rates,
+	.n_bitrates	= ARRAY_SIZE(wcn_2ghz_rates),
 	.ht_cap		= {
 		.cap = IEEE80211_HT_CAP_GRN_FLD | IEEE80211_HT_CAP_SGI_20 |
 			(1 << IEEE80211_HT_CAP_RX_STBC_SHIFT),

--- a/main.c
+++ b/main.c
@@ -452,6 +452,14 @@ static void wcn36xx_update_allowed_rates(struct wcn36xx *wcn,
 		}
 	}
 
+	if (sta->ht_cap.ht_supported) {
+		memcpy(wcn->supported_rates.supported_mcs_set,
+		       sta->ht_cap.mcs.rx_mask,
+		       sizeof(sta->ht_cap.mcs.rx_mask));
+		BUILD_BUG_ON(sizeof(sta->ht_cap.mcs.rx_mask) >
+			     sizeof(wcn->supported_rates.supported_mcs_set));
+	}
+
 }
 
 static void wcn36xx_bss_info_changed(struct ieee80211_hw *hw,

--- a/main.c
+++ b/main.c
@@ -100,30 +100,31 @@ static struct ieee80211_channel wcn_5ghz_channels[] = {
 	.hw_value       = (_hw_rate),                   \
 	.hw_value_short = (_hw_rate)  \
 }
+
 static struct ieee80211_rate wcn_legacy_rates[] = {
-	RATE(10, BIT(0), 0),
-	RATE(20, BIT(1), IEEE80211_RATE_SHORT_PREAMBLE),
-	RATE(55, BIT(2), IEEE80211_RATE_SHORT_PREAMBLE),
-	RATE(110, BIT(3), IEEE80211_RATE_SHORT_PREAMBLE),
-	RATE(60, BIT(4), 0),
-	RATE(90, BIT(5), 0),
-	RATE(120, BIT(6), 0),
-	RATE(180, BIT(7), 0),
-	RATE(240, BIT(8), 0),
-	RATE(360, BIT(9), 0),
-	RATE(480, BIT(10), 0),
-	RATE(540, BIT(11), 0)
+	RATE(10, 0x02, 0),
+	RATE(20, 0x04, IEEE80211_RATE_SHORT_PREAMBLE),
+	RATE(55, 0x0B, IEEE80211_RATE_SHORT_PREAMBLE),
+	RATE(110, 0x16, IEEE80211_RATE_SHORT_PREAMBLE),
+	RATE(60, 0x0C, 0),
+	RATE(90, 0x12, 0),
+	RATE(120, 0x18, 0),
+	RATE(180, 0x24, 0),
+	RATE(240, 0x30, 0),
+	RATE(360, 0x48, 0),
+	RATE(480, 0x60, 0),
+	RATE(540, 0x6C, 0)
 };
 
 static struct ieee80211_rate wcn_5ghz_rates[] = {
-	RATE(60, BIT(4), 0),
-	RATE(90, BIT(5), 0),
-	RATE(120, BIT(6), 0),
-	RATE(180, BIT(7), 0),
-	RATE(240, BIT(8), 0),
-	RATE(360, BIT(9), 0),
-	RATE(480, BIT(10), 0),
-	RATE(540, BIT(11), 0)
+	RATE(60, 0x0C, 0),
+	RATE(90, 0x12, 0),
+	RATE(120, 0x18, 0),
+	RATE(180, 0x24, 0),
+	RATE(240, 0x30, 0),
+	RATE(360, 0x48, 0),
+	RATE(480, 0x60, 0),
+	RATE(540, 0x6C, 0)
 };
 
 static struct ieee80211_supported_band wcn_band_2ghz = {

--- a/smd.c
+++ b/smd.c
@@ -505,7 +505,7 @@ int wcn36xx_smd_config_sta(struct wcn36xx *wcn, const u8 *bssid,
 
 	sta->listen_interval = 0x8;
 	sta->wmm_enabled = 0;
-	sta->ht_capable = 0;
+	sta->ht_capable = wcn->supported_rates.supported_mcs_set[0] ? 1 : 0;
 	sta->tx_channel_width_set = 0;
 	sta->rifs_mode = 0;
 	sta->lsig_txop_protection = 0;
@@ -726,7 +726,7 @@ int wcn36xx_smd_config_bss(struct wcn36xx *wcn, enum nl80211_iftype type,
 		wcn36xx_warn("Unknown type for bss config: %d", type);
 	}
 
-	bss->nw_type = WCN36XX_HAL_11G_NW_TYPE;
+	bss->nw_type = WCN36XX_HAL_11N_NW_TYPE;
 	bss->short_slot_time_supported = 0;
 	bss->lla_coexist = 0;
 	bss->llb_coexist = 0;
@@ -750,7 +750,7 @@ int wcn36xx_smd_config_bss(struct wcn36xx *wcn, enum nl80211_iftype type,
 	memcpy(&sta->mac, &wcn->addresses[0], ETH_ALEN);
 	sta->listen_interval = 8;
 	sta->wmm_enabled = 0;
-	sta->ht_capable = 0;
+	sta->ht_capable = wcn->supported_rates.supported_mcs_set[0] ? 1 : 0;
 	sta->tx_channel_width_set = 0;
 	sta->rifs_mode = 0;
 	sta->lsig_txop_protection = 0;


### PR DESCRIPTION
The goal of this patch set is twofold.

1) I wanted to adapt the rates the STA used to be based
on the intersection of rates between the AP and STA.
Up until now, we've sent ofdm-rates to b-only APs.
Enabling n-rates would make this worse.

2) I wanted to enable n-rates
