### PR TITLE
Cleanup encryption implementation

### DIFF
--- a/dxe.c
+++ b/dxe.c
@@ -576,16 +576,7 @@ int wcn36xx_dxe_tx(struct wcn36xx *wcn,
 	}
 
 	wcn36xx_prepare_tx_bd(ctl->bd_cpu_addr, skb->len, header_len);
-	/* Do not encrypt NULL and MGMT frames */
-	if (!is_high && WCN36XX_BSS_KEY == wcn->en_state &&
-	    !ieee80211_is_nullfunc(hdr->frame_control)) {
-		wcn36xx_dbg(WCN36XX_DBG_DXE, "DXE Encription enabled");
-		wcn36xx_fill_tx_bd(wcn, ctl->bd_cpu_addr, broadcast, 0, hdr,
-				   tx_ack);
-	} else {
-		wcn36xx_fill_tx_bd(wcn, ctl->bd_cpu_addr, broadcast, 1, hdr,
-				   tx_ack);
-	}
+	wcn36xx_fill_tx_bd(wcn, ctl->bd_cpu_addr, broadcast, hdr, tx_ack);
 
 	ctl = ch->head_blk_ctl;
 	desc = ctl->desc;

--- a/txrx.c
+++ b/txrx.c
@@ -84,7 +84,7 @@ void wcn36xx_prepare_tx_bd(struct wcn36xx_tx_bd *bd, u32 len, u32 header_len)
 	bd->pdu.mpdu_len = len;
 }
 void wcn36xx_fill_tx_bd(struct wcn36xx *wcn, struct wcn36xx_tx_bd *bd,
-			u8 broadcast, u8 encrypt, struct ieee80211_hdr *hdr,
+			u8 broadcast, struct ieee80211_hdr *hdr,
 			bool tx_compl)
 {
 	bd->dpu_rf = WCN36XX_BMU_WQ_TX;
@@ -124,12 +124,15 @@ void wcn36xx_fill_tx_bd(struct wcn36xx *wcn, struct wcn36xx_tx_bd *bd,
 		bd->queue_id = 0;
 		bd->sta_index = wcn->current_vif->sta_index;
 		bd->dpu_desc_idx = wcn->current_vif->dpu_desc_index;
+		if (ieee80211_is_nullfunc(hdr->frame_control))
+			bd->dpu_ne = 1;
+
 	} else {
 		bd->sta_index = wcn->current_vif->self_sta_index;
 		bd->dpu_desc_idx = wcn->current_vif->self_dpu_desc_index;
+		bd->dpu_ne = 1;
 	}
 
-	bd->dpu_ne = encrypt;
 	bd->tx_comp = tx_compl;
 
 	buff_to_be((u32 *)bd, sizeof(*bd)/sizeof(u32));

--- a/txrx.h
+++ b/txrx.h
@@ -151,6 +151,6 @@ struct wcn36xx_tx_bd {
 int  wcn36xx_rx_skb(struct wcn36xx *wcn, struct sk_buff *skb);
 void wcn36xx_prepare_tx_bd(struct wcn36xx_tx_bd *bd, u32 len, u32 header_len);
 void wcn36xx_fill_tx_bd(struct wcn36xx *wcn, struct wcn36xx_tx_bd *bd,
-			u8 broadcast, u8 encrypt, struct ieee80211_hdr *hdr,
+			u8 broadcast, struct ieee80211_hdr *hdr,
 			bool tx_compl);
 #endif	/* _TXRX_H_ */

--- a/wcn36xx.h
+++ b/wcn36xx.h
@@ -75,11 +75,6 @@ enum wcn36xx_debug_mask {
 			       buf, len, false);		\
 } while (0)
 
-enum wcn36xx_encryption_state {
-	WCN36XX_STA_KEY,
-	WCN36XX_BSS_KEY
-};
-
 static inline void buff_to_be(u32 *buf, size_t len)
 {
 	int i;
@@ -121,7 +116,6 @@ struct wcn36xx {
 	u8			fw_version;
 	u8			fw_minor;
 	u8			fw_major;
-	enum wcn36xx_encryption_state	en_state;
 
 	/* extra byte for the NULL termination */
 	u8			crm_version[WCN36XX_HAL_VERSION_LENGTH + 1];


### PR DESCRIPTION
This commit cleans up the encryption implementation by removing
unnecessary stuff like the en_state and the encrypt parameter.
