### PR TITLE
 Initial WoW support

### DIFF
--- a/hal.h
+++ b/hal.h
@@ -2956,7 +2956,7 @@ struct wcn36xx_hal_missed_beacon_ind_msg {
 	struct wcn36xx_hal_msg_header header;
 
 	u8 bss_index;
-};
+} __packed;
 
 /* Beacon Filtering data structures */
 

--- a/hal.h
+++ b/hal.h
@@ -2943,14 +2943,14 @@ struct wcn36xx_hal_enter_bmps_req_msg {
 
 	u32 num_beacon_per_rssi_average;
 	u8 rssi_filter_enable;
-};
+} __packed;
 
 struct wcn36xx_hal_exit_bmps_req_msg {
 	struct wcn36xx_hal_msg_header header;
 
 	u8 send_data_null;
 	u8 bss_index;
-};
+} __packed;
 
 struct wcn36xx_hal_missed_beacon_ind_msg {
 	struct wcn36xx_hal_msg_header header;
@@ -3284,7 +3284,7 @@ struct wcn36xx_hal_enter_bmps_rsp_msg {
 	u32 status;
 
 	u8 bss_index;
-};
+} __packed;
 
 struct wcn36xx_hal_exit_bmps_rsp_msg {
 	struct wcn36xx_hal_msg_header header;
@@ -3293,7 +3293,7 @@ struct wcn36xx_hal_exit_bmps_rsp_msg {
 	u32 status;
 
 	u8 bss_index;
-};
+} __packed;
 
 struct wcn36xx_hal_enter_uapsd_rsp_msg {
 	struct wcn36xx_hal_msg_header header;

--- a/main.c
+++ b/main.c
@@ -752,7 +752,8 @@ static int wcn36xx_init_ieee80211(struct wcn36xx *wcn)
 	};
 
 	wcn->hw->flags = IEEE80211_HW_SIGNAL_DBM |
-		IEEE80211_HW_HAS_RATE_CONTROL;
+		IEEE80211_HW_HAS_RATE_CONTROL |
+		IEEE80211_HW_TIMING_BEACON_ONLY;
 
 	wcn->hw->wiphy->interface_modes = BIT(NL80211_IFTYPE_STATION) |
 		BIT(NL80211_IFTYPE_AP) |

--- a/smd.c
+++ b/smd.c
@@ -1020,6 +1020,34 @@ int wcn36xx_smd_remove_bsskey(struct wcn36xx *wcn,
 
 	return wcn36xx_smd_send_and_wait(wcn, msg_body.header.len);
 }
+
+int wcn36xx_smd_enter_bmps(struct wcn36xx *wcn, u64 tbtt)
+{
+	struct wcn36xx_hal_enter_bmps_req_msg msg_body;
+
+	INIT_HAL_MSG(msg_body, WCN36XX_HAL_ENTER_BMPS_REQ);
+
+	msg_body.bss_index = 0;
+	msg_body.tbtt = tbtt;
+	msg_body.dtim_period = wcn->dtim_period;
+
+	PREPARE_HAL_BUF(wcn->smd_buf, msg_body);
+
+	return wcn36xx_smd_send_and_wait(wcn, msg_body.header.len);
+}
+
+int wcn36xx_smd_exit_bmps(struct wcn36xx *wcn)
+{
+	struct wcn36xx_hal_enter_bmps_req_msg msg_body;
+
+	INIT_HAL_MSG(msg_body, WCN36XX_HAL_EXIT_BMPS_REQ);
+
+	msg_body.bss_index = 0;
+
+	PREPARE_HAL_BUF(wcn->smd_buf, msg_body);
+
+	return wcn36xx_smd_send_and_wait(wcn, msg_body.header.len);
+}
 static void wcn36xx_smd_notify(void *data, unsigned event)
 {
 	struct wcn36xx *wcn = (struct wcn36xx *)data;
@@ -1091,6 +1119,8 @@ static void wcn36xx_smd_rsp_process(struct wcn36xx *wcn, void *buf, size_t len)
 	case WCN36XX_HAL_SET_STAKEY_RSP:
 	case WCN36XX_HAL_RMV_STAKEY_RSP:
 	case WCN36XX_HAL_RMV_BSSKEY_RSP:
+	case WCN36XX_HAL_ENTER_BMPS_RSP:
+	case WCN36XX_HAL_EXIT_BMPS_RSP:
 		if (wcn36xx_smd_rsp_status_check(buf, len)) {
 			wcn36xx_warn("error response from hal request %d",
 				     msg_header->msg_type);

--- a/smd.h
+++ b/smd.h
@@ -87,6 +87,8 @@ int wcn36xx_smd_remove_stakey(struct wcn36xx *wcn,
 int wcn36xx_smd_remove_bsskey(struct wcn36xx *wcn,
 			      enum ani_ed_type enc_type,
 			      u8 keyidx);
+int wcn36xx_smd_enter_bmps(struct wcn36xx *wcn, u64 tbtt);
+int wcn36xx_smd_exit_bmps(struct wcn36xx *wcn);
 
 /* WCN36XX configuration parameters */
 struct wcn36xx_fw_cfg {

--- a/wcn36xx.h
+++ b/wcn36xx.h
@@ -113,6 +113,12 @@ struct wcn36xx {
 	u16			beacon_interval;
 	u8			dtim_period;
 	enum ani_ed_type	encrypt_type;
+
+	/* WoW related*/
+	struct mutex		pm_mutex;
+	bool			is_suspended;
+	bool			is_con_lost_pending;
+
 	u8			fw_revision;
 	u8			fw_version;
 	u8			fw_minor;


### PR DESCRIPTION
To support WoW wcn36xx needs to support following commands:
enter/exit_bmps - will tell FW to turn off/on the radio to save power
missed_beacon - FW will notify driver that connection is lost in BMPS mode
