### PR TITLE
Synchronize smd commands

### DIFF
--- a/main.c
+++ b/main.c
@@ -945,6 +945,7 @@ static int __init wcn36xx_init(void)
 	wcn->is_joining = false;
 
 	mutex_init(&wcn->pm_mutex);
+	mutex_init(&wcn->smd_mutex);
 	wcn->hw->wiphy->n_addresses = ARRAY_SIZE(wcn->addresses);
 	wcn->hw->wiphy->addresses = wcn->addresses;
 
@@ -1002,6 +1003,7 @@ static void __exit wcn36xx_exit(void)
 	struct wcn36xx *wcn = hw->priv;
 
 	mutex_destroy(&wcn->pm_mutex);
+	mutex_destroy(&wcn->smd_mutex);
 	ieee80211_unregister_hw(hw);
 	destroy_workqueue(wcn->wq);
 	iounmap(wcn->mmio);

--- a/wcn36xx.h
+++ b/wcn36xx.h
@@ -139,7 +139,13 @@ struct wcn36xx {
 
 	/* SMD related */
 	smd_channel_t		*smd_ch;
+	/*
+	 * smd_buf must be protected with smd_mutex to garantee
+	 * that all messages are sent one after another
+	 */
 	u8			*smd_buf;
+	struct mutex		smd_mutex;
+
 	struct work_struct	smd_work;
 	struct work_struct	start_work;
 	struct work_struct	rx_ready_work;


### PR DESCRIPTION
Add protection to smd api to make sure all smd
commands are sent sequentially.

Signed-off-by: Eugene Krasnikov k.eugene.e@gmail.com
