### PR TITLE
Refactor TX path

### DIFF
--- a/dxe.h
+++ b/dxe.h
@@ -222,8 +222,6 @@ struct wcn36xx_dxe_mem_pool {
 	void		*virt_addr;
 	dma_addr_t	phy_addr;
 };
-struct wcn36xx;
-struct wcn_sta;
 int wcn36xx_dxe_allocate_mem_pools(struct wcn36xx *wcn);
 void wcn36xx_dxe_free_mem_pools(struct wcn36xx *wcn);
 void wcn36xx_rx_ready_work(struct work_struct *work);
@@ -232,12 +230,9 @@ void wcn36xx_dxe_free_ctl_blks(struct wcn36xx *wcn);
 int wcn36xx_dxe_init(struct wcn36xx *wcn);
 void wcn36xx_dxe_deinit(struct wcn36xx *wcn);
 int wcn36xx_dxe_init_channels(struct wcn36xx *wcn);
-int wcn36xx_dxe_tx(struct wcn36xx *wcn,
-		   struct sk_buff *skb,
-		   u8 broadcast,
-		   bool is_high,
-		   u32 header_len,
-		   bool tx_compl,
-		   struct wcn_sta *sta_priv);
+int wcn36xx_dxe_tx_frame(struct wcn36xx *wcn,
+			 struct sk_buff *skb,
+			 bool is_low);
 void wcn36xx_dxe_tx_ack_ind(struct wcn36xx *wcn, u32 status);
+void *wcn36xx_dxe_get_next_bd(struct wcn36xx *wcn, bool is_low);
 #endif	/* _DXE_H_ */

--- a/txrx.h
+++ b/txrx.h
@@ -17,6 +17,7 @@
 #ifndef _TXRX_H_
 #define _TXRX_H_
 
+#include <linux/etherdevice.h>
 #include "wcn36xx.h"
 
 /* TODO describe all properties */
@@ -147,9 +148,13 @@ struct wcn36xx_tx_bd {
 	u32	header_cks:16;
 	u32	reserved7:6;*/
 };
+
+struct wcn_sta;
+struct wcn36xx;
+
 int  wcn36xx_rx_skb(struct wcn36xx *wcn, struct sk_buff *skb);
-void wcn36xx_prepare_tx_bd(struct wcn36xx_tx_bd *bd, u32 len, u32 header_len);
-void wcn36xx_fill_tx_bd(struct wcn36xx *wcn, struct wcn36xx_tx_bd *bd,
-			u8 broadcast, struct ieee80211_hdr *hdr,
-			bool tx_compl, struct wcn_sta *sta_priv);
+int wcn36xx_start_tx(struct wcn36xx *wcn,
+		     struct wcn_sta *sta_priv,
+		     struct sk_buff *skb);
+
 #endif	/* _TXRX_H_ */

--- a/wcn36xx.h
+++ b/wcn36xx.h
@@ -27,6 +27,7 @@
 
 #include "hal.h"
 #include "smd.h"
+#include "txrx.h"
 #include "dxe.h"
 
 #define DRIVER_PREFIX "wcn36xx: "


### PR DESCRIPTION
With this patch all parameters will be first passed to txrx
module and only after that to dxe. This will allow passing
less parameters to the functions. Also make sure that data
frames will get as fast as possible to the HW.

Short function description:

wcn36xx_start_tx - fills in BD and trigger dxe to start
transmitting.

wcn36xx_set_tx_pdu - fills in PDU part of BD.

wcn36xx_set_tx_data - set data specific BD parameters

wcn36xx_set_tx_mgmt - set BD parameters that are specific to
management and control frames.

wcn36xx_dxe_tx_frame - transmits one frame from the head
of the descriptors.

Signed-off-by: Eugene Krasnikov k.eugene.e@gmail.com
