### PR TITLE
Remove firmware allocation from wcn struct

### DIFF
--- a/wcn36xx.h
+++ b/wcn36xx.h
@@ -19,7 +19,6 @@
 
 #include <linux/completion.h>
 #include <linux/printk.h>
-#include <linux/firmware.h>
 #include <linux/spinlock.h>
 #include <linux/workqueue.h>
 #include <mach/msm_smd.h>
@@ -112,7 +111,6 @@ struct wcn36xx {
 	struct ieee80211_hw	*hw;
 	struct workqueue_struct	*wq;
 	struct device		*dev;
-	const struct firmware	*nv;
 	struct mac_address	addresses[2];
 	struct wcn36xx_hal_mac_ssid ssid;
 	u16			aid;


### PR DESCRIPTION
Remove the nv pointer from the wcn struct and keep it inside the
smd_load_nv function as local. This way we don't keep it allocated
throught the life of the module and won't waste memory.

This commit also includes minor cleanup of unused variables in the
smd_load_nv function.

Signed-off-by: Olof Johansson dev@skyshaper.net
