### PR TITLE
Back off if ring buffer is full

### DIFF
--- a/dxe.h
+++ b/dxe.h
@@ -195,6 +195,7 @@ struct wcn36xx_dxe_ctl {
 	unsigned int		desc_phy_addr;
 	int			ctl_blk_order;
 	struct sk_buff		*skb;
+	spinlock_t              skb_lock;
 	void			*bd_cpu_addr;
 	dma_addr_t		bd_phy_addr;
 };

--- a/wcn36xx.h
+++ b/wcn36xx.h
@@ -166,6 +166,7 @@ struct wcn36xx {
 
 	/* For synchronization of DXE resources from BH, IRQ and WQ contexts */
 	spinlock_t	dxe_lock;
+	bool                    queues_stopped;
 
 	/* Memory pools */
 	struct wcn36xx_dxe_mem_pool mgmt_mem_pool;


### PR DESCRIPTION
If ring is full stop mac80211 queues so upper layers will not try to
send any frames until bottom half has capacity for sending frames.

Signed-off-by: Eugene Krasnikov k.eugene.e@gmail.com
