### PR TITLE
Config bss

### DIFF
--- a/smd.c
+++ b/smd.c
@@ -66,16 +66,20 @@ static void wcn36xx_smd_set_sta_params(struct wcn36xx *wcn,
 	 * contains our mac address. In  AP mode we are bssid so vif
 	 * contains bssid and ieee80211_sta contains mac.
 	 */
-	if (NL80211_IFTYPE_STATION == vif->type) {
-		memcpy(&sta_params->bssid, sta->addr, ETH_ALEN);
+	if (NL80211_IFTYPE_STATION == vif->type)
 		memcpy(&sta_params->mac, vif->addr, ETH_ALEN);
-	} else {
+	else
 		memcpy(&sta_params->bssid, vif->addr, ETH_ALEN);
-		memcpy(&sta_params->mac, sta->addr, ETH_ALEN);
+
+	if (sta) {
+		if (NL80211_IFTYPE_STATION == vif->type)
+			memcpy(&sta_params->bssid, sta->addr, ETH_ALEN);
+		else
+			memcpy(&sta_params->mac, sta->addr, ETH_ALEN);
+		sta_params->wmm_enabled = sta->wme;
+		sta_params->max_sp_len = sta->max_sp;
+		wcn36xx_smd_set_sta_ht_params(sta, sta_params);
 	}
-	sta_params->wmm_enabled = sta->wme;
-	sta_params->max_sp_len = sta->max_sp;
-	wcn36xx_smd_set_sta_ht_params(sta, sta_params);
 }
 static int wcn36xx_smd_send_and_wait(struct wcn36xx *wcn, size_t len)
 {
@@ -826,8 +830,7 @@ int wcn36xx_smd_config_bss(struct wcn36xx *wcn, struct ieee80211_vif *vif,
 	else
 		bss->ext_channel = IEEE80211_HT_PARAM_CHA_SEC_NONE;
 	bss->reserved = 0;
-	if (sta)
-		wcn36xx_smd_set_sta_params(wcn, vif, sta, sta_params);
+	wcn36xx_smd_set_sta_params(wcn, vif, sta, sta_params);
 	sta_params->short_preamble_supported = 0;
 	sta_params->rifs_mode = 0;
 

--- a/txrx.c
+++ b/txrx.c
@@ -32,6 +32,9 @@ int wcn36xx_rx_skb(struct wcn36xx *wcn, struct sk_buff *skb)
 
 	bd = (struct wcn36xx_rx_bd *)skb->data;
 	buff_to_be((u32 *)bd, sizeof(*bd)/sizeof(u32));
+	wcn36xx_dbg_dump(WCN36XX_DBG_RX_DUMP,
+			 "BD   <<< ", (char *)bd,
+			 sizeof(struct wcn36xx_rx_bd));
 
 	skb_put(skb, bd->pdu.mpdu_header_off + bd->pdu.mpdu_len);
 	skb_pull(skb, bd->pdu.mpdu_header_off);


### PR DESCRIPTION
Crashes in RX path were observed so to trace them add RX BD dumping.
Also rework wcn36xx_smd_set_sta_params so it can be called with sta = NULL.
This is needed because not all sta_params are taken from sta struct.
