### PR TITLE
wcn36xx: do not notify about changed filters

### DIFF
--- a/main.c
+++ b/main.c
@@ -309,7 +309,6 @@ static void wcn36xx_configure_filter(struct ieee80211_hw *hw,
 {
 	wcn36xx_dbg(WCN36XX_DBG_MAC, "mac configure filter\n");
 
-	changed &= WCN36XX_SUPPORTED_FILTERS;
 	*total &= WCN36XX_SUPPORTED_FILTERS;
 }
 


### PR DESCRIPTION
No need for this line since wcn36xx does not support any filters so far.

Signed-off-by: Eugene Krasnikov k.eugene.e@gmail.com
