### PR TITLE
wcn36xx: rework wcn36xx_add_interface

### DIFF
--- a/main.c
+++ b/main.c
@@ -659,22 +659,16 @@ static int wcn36xx_add_interface(struct ieee80211_hw *hw,
 
 	wcn->current_vif = (struct wcn36xx_vif *)vif->drv_priv;
 
-	switch (vif->type) {
-	case NL80211_IFTYPE_STATION:
-		wcn36xx_smd_add_sta_self(wcn, vif->addr, 0);
-		break;
-	case NL80211_IFTYPE_AP:
-		wcn36xx_smd_add_sta_self(wcn, vif->addr, 0);
-		break;
-	case NL80211_IFTYPE_ADHOC:
-	case NL80211_IFTYPE_MESH_POINT:
-		wcn36xx_smd_add_sta_self(wcn, vif->addr, 0);
-		break;
-	default:
+	if (!(NL80211_IFTYPE_STATION == vif->type ||
+	      NL80211_IFTYPE_AP == vif->type ||
+	      NL80211_IFTYPE_ADHOC == vif->type ||
+	      NL80211_IFTYPE_MESH_POINT == vif->type)) {
 		wcn36xx_warn("Unsupported interface type requested: %d\n",
 			     vif->type);
 		return -EOPNOTSUPP;
 	}
+
+	wcn36xx_smd_add_sta_self(wcn, vif->addr);
 
 	return 0;
 }

--- a/smd.c
+++ b/smd.c
@@ -469,14 +469,13 @@ static int wcn36xx_smd_update_scan_params_rsp(void *buf, size_t len)
 	return 0;
 }
 
-int wcn36xx_smd_add_sta_self(struct wcn36xx *wcn, u8 *addr, u32 status)
+int wcn36xx_smd_add_sta_self(struct wcn36xx *wcn, u8 *addr)
 {
 	struct wcn36xx_hal_add_sta_self_req msg_body;
 
 	INIT_HAL_MSG(msg_body, WCN36XX_HAL_ADD_STA_SELF_REQ);
 
 	memcpy(&msg_body.self_addr, addr, ETH_ALEN);
-	msg_body.status = status;
 
 	PREPARE_HAL_BUF(wcn->smd_buf, msg_body);
 

--- a/smd.h
+++ b/smd.h
@@ -57,7 +57,7 @@ int wcn36xx_smd_start_scan(struct wcn36xx *wcn);
 int wcn36xx_smd_end_scan(struct wcn36xx *wcn);
 int wcn36xx_smd_finish_scan(struct wcn36xx *wcn);
 int wcn36xx_smd_update_scan_params(struct wcn36xx *wcn);
-int wcn36xx_smd_add_sta_self(struct wcn36xx *wcn, u8 *addr, u32 status);
+int wcn36xx_smd_add_sta_self(struct wcn36xx *wcn, u8 *addr);
 int wcn36xx_smd_delete_sta_self(struct wcn36xx *wcn, u8 *addr);
 int wcn36xx_smd_delete_sta(struct wcn36xx *wcn, u8 sta_index);
 int wcn36xx_smd_join(struct wcn36xx *wcn, const u8 *bssid, u8 *vif, u8 ch);


### PR DESCRIPTION
No need to use switch in add interface.

Signed-off-by: Eugene Krasnikov k.eugene.e@gmail.com
