### PR TITLE
Remove current_vif and sta from wcn36xx struct

### DIFF
--- a/debug.c
+++ b/debug.c
@@ -35,13 +35,22 @@ static ssize_t read_file_bool_bmps(struct file *file, char __user *user_buf,
 				   size_t count, loff_t *ppos)
 {
 	struct wcn36xx *wcn = file->private_data;
+	struct wcn36xx_vif *vif_priv = NULL;
+	struct ieee80211_vif *vif = NULL;
 	char buf[3];
 
-	if (wcn->pw_state == WCN36XX_BMPS)
-		buf[0] = '1';
-	else
-		buf[0] = '0';
-
+	list_for_each_entry(vif_priv, &wcn->vif_list, list) {
+			vif = container_of((void *)vif_priv,
+				   struct ieee80211_vif,
+				   drv_priv);
+			if (NL80211_IFTYPE_STATION == vif->type) {
+				if (vif_priv->pw_state == WCN36XX_BMPS)
+					buf[0] = '1';
+				else
+					buf[0] = '0';
+				break;
+			}
+	}
 	buf[1] = '\n';
 	buf[2] = 0x00;
 

--- a/dxe.c
+++ b/dxe.c
@@ -655,7 +655,7 @@ int wcn36xx_dxe_tx_frame(struct wcn36xx *wcn,
 	 * mode and writing to the register will not wake up the chip. Instead
 	 * notify chip about new frame through SMSM bus.
 	 */
-	if (wcn->pw_state == WCN36XX_BMPS) {
+	if (is_low &&  wcn->current_vif->pw_state == WCN36XX_BMPS) {
 		wcn->ctrl_ops->smsm_change_state(
 				  0,
 				  WCN36XX_SMSM_WLAN_TX_ENABLE);

--- a/dxe.c
+++ b/dxe.c
@@ -577,6 +577,7 @@ void wcn36xx_dxe_free_mem_pools(struct wcn36xx *wcn)
 }
 
 int wcn36xx_dxe_tx_frame(struct wcn36xx *wcn,
+			 struct wcn36xx_vif *vif_priv,
 			 struct sk_buff *skb,
 			 bool is_low)
 {
@@ -655,7 +656,7 @@ int wcn36xx_dxe_tx_frame(struct wcn36xx *wcn,
 	 * mode and writing to the register will not wake up the chip. Instead
 	 * notify chip about new frame through SMSM bus.
 	 */
-	if (is_low &&  wcn->current_vif->pw_state == WCN36XX_BMPS) {
+	if (is_low &&  vif_priv->pw_state == WCN36XX_BMPS) {
 		wcn->ctrl_ops->smsm_change_state(
 				  0,
 				  WCN36XX_SMSM_WLAN_TX_ENABLE);

--- a/dxe.h
+++ b/dxe.h
@@ -265,6 +265,8 @@ struct wcn36xx_dxe_mem_pool {
 	void		*virt_addr;
 	dma_addr_t	phy_addr;
 };
+
+struct wcn36xx_vif;
 int wcn36xx_dxe_allocate_mem_pools(struct wcn36xx *wcn);
 void wcn36xx_dxe_free_mem_pools(struct wcn36xx *wcn);
 void wcn36xx_dxe_rx_frame(struct wcn36xx *wcn);
@@ -274,6 +276,7 @@ int wcn36xx_dxe_init(struct wcn36xx *wcn);
 void wcn36xx_dxe_deinit(struct wcn36xx *wcn);
 int wcn36xx_dxe_init_channels(struct wcn36xx *wcn);
 int wcn36xx_dxe_tx_frame(struct wcn36xx *wcn,
+			 struct wcn36xx_vif *vif_priv,
 			 struct sk_buff *skb,
 			 bool is_low);
 void wcn36xx_dxe_tx_ack_ind(struct wcn36xx *wcn, u32 status);

--- a/main.c
+++ b/main.c
@@ -494,7 +494,6 @@ static void wcn36xx_bss_info_changed(struct ieee80211_hw *hw,
 	u16 tim_off, tim_len;
 	enum wcn36xx_hal_link_state link_state;
 	struct wcn36xx_vif *vif_priv = (struct wcn36xx_vif *)vif->drv_priv;
-	wcn->current_vif = vif_priv;
 
 	wcn36xx_dbg(WCN36XX_DBG_MAC, "mac bss info changed vif %p changed 0x%08x\n",
 		    vif, changed);
@@ -670,7 +669,6 @@ static int wcn36xx_add_interface(struct ieee80211_hw *hw,
 {
 	struct wcn36xx *wcn = hw->priv;
 	struct wcn36xx_vif *vif_priv = (struct wcn36xx_vif *)vif->drv_priv;
-	wcn->current_vif = vif_priv;
 
 	wcn36xx_dbg(WCN36XX_DBG_MAC, "mac add interface vif %p type %d\n",
 		    vif, vif->type);

--- a/main.c
+++ b/main.c
@@ -524,14 +524,14 @@ static void wcn36xx_bss_info_changed(struct ieee80211_hw *hw,
 			    bss_conf->bssid);
 
 		if (!is_zero_ether_addr(bss_conf->bssid)) {
-			wcn->is_joining = true;
+			vif_priv->is_joining = true;
 			vif_priv->bss_index = 0xff;
 			wcn36xx_smd_join(wcn, bss_conf->bssid,
 					 vif->addr, WCN36XX_HW_CHANNEL(wcn));
 			wcn36xx_smd_config_bss(wcn, vif, NULL,
 					       bss_conf->bssid, false);
 		} else {
-			wcn->is_joining = false;
+			vif_priv->is_joining = false;
 			wcn36xx_smd_delete_bss(wcn, vif);
 		}
 	}
@@ -547,7 +547,7 @@ static void wcn36xx_bss_info_changed(struct ieee80211_hw *hw,
 	}
 
 	if (changed & BSS_CHANGED_ASSOC) {
-		wcn->is_joining = false;
+		vif_priv->is_joining = false;
 		if (bss_conf->assoc) {
 			struct ieee80211_sta *sta;
 			struct wcn36xx_sta *sta_priv;

--- a/main.c
+++ b/main.c
@@ -539,8 +539,10 @@ static void wcn36xx_bss_info_changed(struct ieee80211_hw *hw,
 		wcn36xx_dbg_dump(WCN36XX_DBG_MAC, "ssid ",
 				 bss_conf->ssid, bss_conf->ssid_len);
 
-		wcn->ssid.length = bss_conf->ssid_len;
-		memcpy(&wcn->ssid.ssid, bss_conf->ssid, bss_conf->ssid_len);
+		vif_priv->ssid.length = bss_conf->ssid_len;
+		memcpy(&vif_priv->ssid.ssid,
+		       bss_conf->ssid,
+		       bss_conf->ssid_len);
 	}
 
 	if (changed & BSS_CHANGED_ASSOC) {

--- a/main.c
+++ b/main.c
@@ -700,7 +700,8 @@ static int wcn36xx_sta_add(struct ieee80211_hw *hw, struct ieee80211_vif *vif,
 		    vif, sta->addr);
 
 	wcn->sta = (struct wcn36xx_sta *)sta->drv_priv;
-	vif_priv->sta = (struct wcn36xx_sta *)sta->drv_priv;
+	vif_priv->sta = sta_priv;
+	sta_priv->vif = vif_priv;
 	/*
 	 * For STA mode HW will be configured on BSS_CHANGED_ASSOC because
 	 * at this stage AID is not available yet.
@@ -725,6 +726,7 @@ static int wcn36xx_sta_remove(struct ieee80211_hw *hw,
 
 	wcn36xx_smd_delete_sta(wcn, sta_priv->sta_index);
 	vif_priv->sta = NULL;
+	sta_priv->vif = NULL;
 	return 0;
 }
 

--- a/main.c
+++ b/main.c
@@ -230,7 +230,6 @@ static int wcn36xx_start(struct ieee80211_hw *hw)
 		goto out_smd_stop;
 	}
 
-	wcn36xx_pmc_init(wcn);
 	wcn36xx_debugfs_init(wcn);
 
 	if (!wcn36xx_is_fw_version(wcn, 1, 2, 2, 24)) {

--- a/main.c
+++ b/main.c
@@ -319,7 +319,7 @@ static int wcn36xx_set_key(struct ieee80211_hw *hw, enum set_key_cmd cmd,
 {
 	struct wcn36xx *wcn = hw->priv;
 	struct wcn36xx_vif *vif_priv = (struct wcn36xx_vif *)vif->drv_priv;
-	struct wcn36xx_sta *sta_priv = NULL;
+	struct wcn36xx_sta *sta_priv = vif_priv->sta;
 	int ret = 0;
 	u8 key[WLAN_MAX_KEY_LEN];
 
@@ -330,7 +330,6 @@ static int wcn36xx_set_key(struct ieee80211_hw *hw, enum set_key_cmd cmd,
 	wcn36xx_dbg_dump(WCN36XX_DBG_MAC, "KEY: ",
 			 key_conf->key,
 			 key_conf->keylen);
-	sta_priv = sta ? (struct wcn36xx_sta *)sta->drv_priv : wcn->sta;
 
 	switch (key_conf->cipher) {
 	case WLAN_CIPHER_SUITE_WEP40:
@@ -571,7 +570,6 @@ static void wcn36xx_bss_info_changed(struct ieee80211_hw *hw,
 			wcn36xx_smd_set_link_st(wcn, bss_conf->bssid,
 				vif->addr,
 				WCN36XX_HAL_LINK_POSTASSOC_STATE);
-			wcn->sta = sta_priv;
 			wcn36xx_smd_config_bss(wcn, vif, sta,
 					       bss_conf->bssid,
 					       true);
@@ -697,7 +695,6 @@ static int wcn36xx_sta_add(struct ieee80211_hw *hw, struct ieee80211_vif *vif,
 	wcn36xx_dbg(WCN36XX_DBG_MAC, "mac sta add vif %p sta %pM\n",
 		    vif, sta->addr);
 
-	wcn->sta = (struct wcn36xx_sta *)sta->drv_priv;
 	vif_priv->sta = sta_priv;
 	sta_priv->vif = vif_priv;
 	/*

--- a/pmc.c
+++ b/pmc.c
@@ -18,21 +18,16 @@
 
 #include "wcn36xx.h"
 
-int wcn36xx_pmc_init(struct wcn36xx *wcn)
-{
-	wcn->pw_state = WCN36XX_FULL_POWER;
-	return 0;
-}
-
 int wcn36xx_pmc_enter_bmps_state(struct wcn36xx *wcn,
 				 struct ieee80211_vif *vif)
 {
 	int ret = 0;
+	struct wcn36xx_vif *vif_priv = (struct wcn36xx_vif *)vif->drv_priv;
 	/* TODO: Make sure the TX chain clean */
 	ret = wcn36xx_smd_enter_bmps(wcn, vif);
 	if (!ret) {
 		wcn36xx_dbg(WCN36XX_DBG_PMC, "Entered BMPS\n");
-		wcn->pw_state = WCN36XX_BMPS;
+		vif_priv->pw_state = WCN36XX_BMPS;
 	} else {
 		/*
 		 * One of the reasons why HW will not enter BMPS is because
@@ -47,12 +42,14 @@ int wcn36xx_pmc_enter_bmps_state(struct wcn36xx *wcn,
 int wcn36xx_pmc_exit_bmps_state(struct wcn36xx *wcn,
 				struct ieee80211_vif *vif)
 {
-	if (WCN36XX_BMPS != wcn->pw_state) {
+	struct wcn36xx_vif *vif_priv = (struct wcn36xx_vif *)vif->drv_priv;
+
+	if (WCN36XX_BMPS != vif_priv->pw_state) {
 		wcn36xx_err("Not in BMPS mode, no need to exit from BMPS mode!\n");
 		return -EINVAL;
 	}
 	wcn36xx_smd_exit_bmps(wcn, vif);
-	wcn->pw_state = WCN36XX_FULL_POWER;
+	vif_priv->pw_state = WCN36XX_FULL_POWER;
 	return 0;
 }
 

--- a/pmc.h
+++ b/pmc.h
@@ -24,7 +24,6 @@ enum wcn36xx_power_state {
 	WCN36XX_BMPS
 };
 
-int wcn36xx_pmc_init(struct wcn36xx *wcn);
 int wcn36xx_pmc_enter_bmps_state(struct wcn36xx *wcn,
 				 struct ieee80211_vif *vif);
 int wcn36xx_pmc_exit_bmps_state(struct wcn36xx *wcn,

--- a/smd.c
+++ b/smd.c
@@ -139,7 +139,7 @@ static void wcn36xx_smd_set_sta_params(struct wcn36xx *wcn,
 	else
 		memcpy(&sta_params->bssid, vif->addr, ETH_ALEN);
 
-	sta_params->encrypt_type = wcn->encrypt_type;
+	sta_params->encrypt_type = priv_vif->encrypt_type;
 	sta_params->short_preamble_supported =
 		!(WCN36XX_FLAGS(wcn) &
 		  IEEE80211_HW_2GHZ_SHORT_PREAMBLE_INCAPABLE);

--- a/smd.c
+++ b/smd.c
@@ -851,11 +851,14 @@ static void wcn36xx_smd_convert_sta_to_v1(struct wcn36xx *wcn,
 	v1->sta_index = orig->sta_index;
 }
 
-static int wcn36xx_smd_config_sta_rsp(struct wcn36xx *wcn, void *buf,
+static int wcn36xx_smd_config_sta_rsp(struct wcn36xx *wcn,
+				      struct ieee80211_sta *sta,
+				      void *buf,
 				      size_t len)
 {
 	struct wcn36xx_hal_config_sta_rsp_msg *rsp;
 	struct config_sta_rsp_params *params;
+	struct wcn36xx_sta *sta_priv = (struct wcn36xx_sta *)sta->drv_priv;
 
 	if (len < sizeof(*rsp))
 		return -EINVAL;
@@ -869,11 +872,8 @@ static int wcn36xx_smd_config_sta_rsp(struct wcn36xx *wcn, void *buf,
 		return -EIO;
 	}
 
-	if (wcn->sta) {
-		wcn->sta->sta_index = params->sta_index;
-		wcn->sta->dpu_desc_index = params->dpu_index;
-		wcn->sta = NULL;
-	}
+	sta_priv->sta_index = params->sta_index;
+	sta_priv->dpu_desc_index = params->dpu_index;
 
 	wcn36xx_dbg(WCN36XX_DBG_HAL,
 		    "hal config sta rsp status %d sta_index %d bssid_index %d p2p %d\n",
@@ -935,7 +935,10 @@ int wcn36xx_smd_config_sta(struct wcn36xx *wcn, struct ieee80211_vif *vif,
 		wcn36xx_err("Sending hal_config_sta failed\n");
 		goto out;
 	}
-	ret = wcn36xx_smd_config_sta_rsp(wcn, wcn->hal_buf, wcn->hal_rsp_len);
+	ret = wcn36xx_smd_config_sta_rsp(wcn,
+					 sta,
+					 wcn->hal_buf,
+					 wcn->hal_rsp_len);
 	if (ret) {
 		wcn36xx_err("hal_config_sta response failed err=%d\n", ret);
 		goto out;
@@ -1085,9 +1088,9 @@ static int wcn36xx_smd_config_bss_rsp(struct wcn36xx *wcn,
 
 	priv_vif->bss_index = params->bss_index;
 
-	if (wcn->sta) {
-		wcn->sta->bss_sta_index =  params->bss_sta_index;
-		wcn->sta->bss_dpu_desc_index = params->dpu_desc_index;
+	if (priv_vif->sta) {
+		priv_vif->sta->bss_sta_index =  params->bss_sta_index;
+		priv_vif->sta->bss_dpu_desc_index = params->dpu_desc_index;
 	}
 
 	priv_vif->ucast_dpu_signature = params->ucast_dpu_signature;

--- a/smd.c
+++ b/smd.c
@@ -1170,8 +1170,8 @@ int wcn36xx_smd_config_bss(struct wcn36xx *wcn, struct ieee80211_vif *vif,
 	wcn36xx_smd_set_sta_params(wcn, vif, sta, sta_params);
 
 	/* wcn->ssid is only valid in AP and IBSS mode */
-	bss->ssid.length = wcn->ssid.length;
-	memcpy(bss->ssid.ssid, wcn->ssid.ssid, wcn->ssid.length);
+	bss->ssid.length = vif_priv->ssid.length;
+	memcpy(bss->ssid.ssid, vif_priv->ssid.ssid, vif_priv->ssid.length);
 
 	bss->obss_prot_enabled = 0;
 	bss->rmf = 0;

--- a/txrx.c
+++ b/txrx.c
@@ -160,7 +160,7 @@ static void wcn36xx_set_tx_mgmt(struct wcn36xx_tx_bd *bd,
 	 * In joining state trick hardware that probe is sent as
 	 * unicast even if address is broadcast.
 	 */
-	if (wcn->is_joining &&
+	if (wcn->current_vif->is_joining &&
 	    ieee80211_is_probe_req(hdr->frame_control))
 		bcast = false;
 

--- a/txrx.c
+++ b/txrx.c
@@ -96,23 +96,42 @@ static void wcn36xx_set_tx_pdu(struct wcn36xx_tx_bd *bd,
 	bd->pdu.tid = tid;
 }
 
+static inline struct wcn36xx_vif *get_vif_by_addr(struct wcn36xx *wcn,
+						  u8 *addr)
+{
+	struct wcn36xx_vif *vif_priv = NULL;
+	struct ieee80211_vif *vif = NULL;
+	list_for_each_entry(vif_priv, &wcn->vif_list, list) {
+			vif = container_of((void *)vif_priv,
+				   struct ieee80211_vif,
+				   drv_priv);
+			if (memcmp(vif->addr, addr, ETH_ALEN) == 0)
+				return vif_priv;
+	}
+	wcn36xx_warn("vif %pM not found\n", addr);
+	return NULL;
+}
 static void wcn36xx_set_tx_data(struct wcn36xx_tx_bd *bd,
 				struct wcn36xx *wcn,
+				struct wcn36xx_vif **vif_priv,
 				struct wcn36xx_sta *sta_priv,
 				struct ieee80211_hdr *hdr,
 				bool bcast)
 {
-	struct ieee80211_vif *vif = container_of((void *)wcn->current_vif,
-						 struct ieee80211_vif,
-						 drv_priv);
+	struct ieee80211_vif *vif = NULL;
+	struct wcn36xx_vif *__vif_priv = NULL;
 	bd->bd_rate = WCN36XX_BD_RATE_DATA;
-	bd->dpu_sign = wcn->current_vif->ucast_dpu_signature;
 
 	/*
 	 * For not unicast frames mac80211 will not set sta pointer so use
 	 * self_sta_index instead.
 	 */
 	if (sta_priv) {
+		__vif_priv = sta_priv->vif;
+		vif = container_of((void *)__vif_priv,
+				   struct ieee80211_vif,
+				   drv_priv);
+
 		if (vif->type == NL80211_IFTYPE_STATION) {
 			bd->sta_index = sta_priv->bss_sta_index;
 			bd->dpu_desc_idx = sta_priv->bss_dpu_desc_index;
@@ -123,9 +142,12 @@ static void wcn36xx_set_tx_data(struct wcn36xx_tx_bd *bd,
 			bd->dpu_desc_idx = sta_priv->dpu_desc_index;
 		}
 	} else {
-		bd->sta_index = wcn->current_vif->self_sta_index;
-		bd->dpu_desc_idx = wcn->current_vif->self_dpu_desc_index;
+		__vif_priv = get_vif_by_addr(wcn, hdr->addr2);
+		bd->sta_index = __vif_priv->self_sta_index;
+		bd->dpu_desc_idx = __vif_priv->self_dpu_desc_index;
 	}
+
+	bd->dpu_sign = __vif_priv->ucast_dpu_signature;
 
 	if (ieee80211_is_nullfunc(hdr->frame_control) ||
 	   (sta_priv && !sta_priv->is_data_encrypted))
@@ -135,15 +157,19 @@ static void wcn36xx_set_tx_data(struct wcn36xx_tx_bd *bd,
 		bd->ub = 1;
 		bd->ack_policy = 1;
 	}
+	*vif_priv = __vif_priv;
 }
 
 static void wcn36xx_set_tx_mgmt(struct wcn36xx_tx_bd *bd,
 				struct wcn36xx *wcn,
+				struct wcn36xx_vif **vif_priv,
 				struct ieee80211_hdr *hdr,
 				bool bcast)
 {
-	bd->sta_index = wcn->current_vif->self_sta_index;
-	bd->dpu_desc_idx = wcn->current_vif->self_dpu_desc_index;
+	struct wcn36xx_vif *__vif_priv =
+		get_vif_by_addr(wcn, hdr->addr2);
+	bd->sta_index = __vif_priv->self_sta_index;
+	bd->dpu_desc_idx = __vif_priv->self_dpu_desc_index;
 	bd->dpu_ne = 1;
 
 	/* default rate for unicast */
@@ -160,7 +186,7 @@ static void wcn36xx_set_tx_mgmt(struct wcn36xx_tx_bd *bd,
 	 * In joining state trick hardware that probe is sent as
 	 * unicast even if address is broadcast.
 	 */
-	if (wcn->current_vif->is_joining &&
+	if (__vif_priv->is_joining &&
 	    ieee80211_is_probe_req(hdr->frame_control))
 		bcast = false;
 
@@ -172,6 +198,7 @@ static void wcn36xx_set_tx_mgmt(struct wcn36xx_tx_bd *bd,
 		bd->queue_id = WCN36XX_TX_B_WQ_ID;
 	} else
 		bd->queue_id = WCN36XX_TX_U_WQ_ID;
+	*vif_priv = __vif_priv;
 }
 
 int wcn36xx_start_tx(struct wcn36xx *wcn,
@@ -179,6 +206,7 @@ int wcn36xx_start_tx(struct wcn36xx *wcn,
 		     struct sk_buff *skb)
 {
 	struct ieee80211_hdr *hdr = (struct ieee80211_hdr *)skb->data;
+	struct wcn36xx_vif *vif_priv = NULL;
 	struct ieee80211_tx_info *info = IEEE80211_SKB_CB(skb);
 	unsigned long flags;
 	bool is_low = ieee80211_is_data(hdr->frame_control);
@@ -233,7 +261,7 @@ int wcn36xx_start_tx(struct wcn36xx *wcn,
 
 	/* Data frames served first*/
 	if (is_low) {
-		wcn36xx_set_tx_data(bd, wcn, sta_priv, hdr, bcast);
+		wcn36xx_set_tx_data(bd, wcn, &vif_priv, sta_priv, hdr, bcast);
 		wcn36xx_set_tx_pdu(bd,
 			   ieee80211_is_data_qos(hdr->frame_control) ?
 			   sizeof(struct ieee80211_qos_hdr) :
@@ -241,7 +269,7 @@ int wcn36xx_start_tx(struct wcn36xx *wcn,
 			   skb->len, sta_priv ? sta_priv->tid : 0);
 	} else {
 		/* MGMT and CTRL frames are handeld here*/
-		wcn36xx_set_tx_mgmt(bd, wcn, hdr, bcast);
+		wcn36xx_set_tx_mgmt(bd, wcn, &vif_priv, hdr, bcast);
 		wcn36xx_set_tx_pdu(bd,
 			   ieee80211_is_data_qos(hdr->frame_control) ?
 			   sizeof(struct ieee80211_qos_hdr) :
@@ -252,5 +280,5 @@ int wcn36xx_start_tx(struct wcn36xx *wcn,
 	buff_to_be((u32 *)bd, sizeof(*bd)/sizeof(u32));
 	bd->tx_bd_sign = 0xbdbdbdbd;
 
-	return wcn36xx_dxe_tx_frame(wcn, skb, is_low);
+	return wcn36xx_dxe_tx_frame(wcn, vif_priv, skb, is_low);
 }

--- a/wcn36xx.h
+++ b/wcn36xx.h
@@ -153,6 +153,7 @@ struct wcn36xx_vif {
  * |______________|_____________|_______________|
  */
 struct wcn36xx_sta {
+	struct wcn36xx_vif *vif;
 	u16 aid;
 	u16 tid;
 	u8 sta_index;

--- a/wcn36xx.h
+++ b/wcn36xx.h
@@ -118,6 +118,7 @@ struct wcn36xx_vif {
 	struct wcn36xx_sta *sta;
 	u8 dtim_period;
 	enum ani_ed_type encrypt_type;
+	bool is_joining;
 	u8 bss_index;
 	u8 ucast_dpu_signature;
 	/* Returned from WCN36XX_HAL_ADD_STA_SELF_RSP */
@@ -196,8 +197,6 @@ struct wcn36xx {
 	struct work_struct	hal_ind_work;
 	struct mutex		hal_ind_mutex;
 	struct list_head	hal_ind_queue;
-
-	bool			is_joining;
 
 	/* DXE channels */
 	struct wcn36xx_dxe_ch	dxe_tx_l_ch;	/* TX low */

--- a/wcn36xx.h
+++ b/wcn36xx.h
@@ -119,6 +119,10 @@ struct wcn36xx_vif {
 	u8 dtim_period;
 	enum ani_ed_type encrypt_type;
 	bool is_joining;
+
+	/* Power management */
+	enum wcn36xx_power_state pw_state;
+
 	u8 bss_index;
 	u8 ucast_dpu_signature;
 	/* Returned from WCN36XX_HAL_ADD_STA_SELF_RSP */
@@ -213,9 +217,6 @@ struct wcn36xx {
 	struct wcn36xx_dxe_mem_pool data_mem_pool;
 
 	struct sk_buff		*tx_ack_skb;
-
-	/* Power management */
-	enum wcn36xx_power_state     pw_state;
 
 #ifdef CONFIG_WCN36XX_DEBUGFS
 	/* Debug file system entry */

--- a/wcn36xx.h
+++ b/wcn36xx.h
@@ -119,6 +119,7 @@ struct wcn36xx_vif {
 	u8 dtim_period;
 	enum ani_ed_type encrypt_type;
 	bool is_joining;
+	struct wcn36xx_hal_mac_ssid ssid;
 
 	/* Power management */
 	enum wcn36xx_power_state pw_state;
@@ -167,7 +168,6 @@ struct wcn36xx {
 	struct ieee80211_hw	*hw;
 	struct device		*dev;
 	struct mac_address	addresses;
-	struct wcn36xx_hal_mac_ssid ssid;
 	struct list_head	vif_list;
 
 	u8			fw_revision;

--- a/wcn36xx.h
+++ b/wcn36xx.h
@@ -169,7 +169,6 @@ struct wcn36xx {
 	struct mac_address	addresses;
 	struct wcn36xx_hal_mac_ssid ssid;
 	struct list_head	vif_list;
-	struct wcn36xx_vif	*current_vif;
 	struct wcn36xx_sta	*sta;
 
 	u8			fw_revision;

--- a/wcn36xx.h
+++ b/wcn36xx.h
@@ -117,6 +117,7 @@ struct wcn36xx_vif {
 	struct list_head list;
 	struct wcn36xx_sta *sta;
 	u8 dtim_period;
+	enum ani_ed_type encrypt_type;
 	u8 bss_index;
 	u8 ucast_dpu_signature;
 	/* Returned from WCN36XX_HAL_ADD_STA_SELF_RSP */
@@ -164,7 +165,6 @@ struct wcn36xx {
 	struct list_head	vif_list;
 	struct wcn36xx_vif	*current_vif;
 	struct wcn36xx_sta	*sta;
-	enum ani_ed_type	encrypt_type;
 
 	u8			fw_revision;
 	u8			fw_version;

--- a/wcn36xx.h
+++ b/wcn36xx.h
@@ -169,7 +169,6 @@ struct wcn36xx {
 	struct mac_address	addresses;
 	struct wcn36xx_hal_mac_ssid ssid;
 	struct list_head	vif_list;
-	struct wcn36xx_sta	*sta;
 
 	u8			fw_revision;
 	u8			fw_version;


### PR DESCRIPTION
This is the final patch set with cleaning wcn36xx struct.
Now adding multiple vif support should not be a problem.
