### PR TITLE
Mesh mode fixes

### DIFF
--- a/main.c
+++ b/main.c
@@ -127,7 +127,8 @@ static struct ieee80211_supported_band wcn_band_2ghz = {
 		.cap =	IEEE80211_HT_CAP_GRN_FLD |
 			IEEE80211_HT_CAP_SGI_20 |
 			IEEE80211_HT_CAP_DSSSCCK40 |
-			IEEE80211_HT_CAP_LSIG_TXOP_PROT,
+			IEEE80211_HT_CAP_LSIG_TXOP_PROT |
+			IEEE80211_HT_CAP_SUP_WIDTH_20_40,
 		.ht_supported = true,
 		.ampdu_factor = IEEE80211_HT_MAX_AMPDU_64K,
 		.ampdu_density = IEEE80211_HT_MPDU_DENSITY_16,

--- a/main.c
+++ b/main.c
@@ -671,9 +671,12 @@ static void wcn36xx_bss_info_changed(struct ieee80211_hw *hw,
 			wcn36xx_smd_set_link_st(wcn, vif->addr, vif->addr,
 						link_state);
 		} else {
-			wcn36xx_smd_set_link_st(wcn, vif->addr, vif->addr,
+			if (vif->type != NL80211_IFTYPE_MESH_POINT) {
+				wcn36xx_smd_set_link_st(wcn, vif->addr,
+						vif->addr,
 						WCN36XX_HAL_LINK_IDLE_STATE);
-			wcn36xx_smd_delete_bss(wcn, vif);
+				wcn36xx_smd_delete_bss(wcn, vif);
+			}
 		}
 	}
 out:

--- a/main.c
+++ b/main.c
@@ -642,7 +642,8 @@ static void wcn36xx_bss_info_changed(struct ieee80211_hw *hw,
 		dev_kfree_skb(skb);
 	}
 
-	if (changed & BSS_CHANGED_BEACON_ENABLED) {
+	if (changed & BSS_CHANGED_BEACON_ENABLED ||
+	    changed & BSS_CHANGED_BEACON) {
 		wcn36xx_dbg(WCN36XX_DBG_MAC,
 			    "mac bss changed beacon enabled %d\n",
 			    bss_conf->enable_beacon);

--- a/smd.c
+++ b/smd.c
@@ -1136,12 +1136,15 @@ int wcn36xx_smd_config_bss(struct wcn36xx *wcn, struct ieee80211_vif *vif,
 		/* AP */
 		bss->oper_mode = 0;
 		bss->wcn36xx_hal_persona = WCN36XX_HAL_STA_SAP_MODE;
-	} else if (vif->type == NL80211_IFTYPE_ADHOC ||
-		   vif->type == NL80211_IFTYPE_MESH_POINT) {
+	} else if (vif->type == NL80211_IFTYPE_ADHOC) {
 		bss->bss_type = WCN36XX_HAL_IBSS_MODE;
 
 		/* STA */
 		bss->oper_mode = 1;
+	} else if (vif->type == NL80211_IFTYPE_MESH_POINT) {
+		/* Work around here to make sure beaconing happend in mesh */
+		bss->bss_type = WCN36XX_HAL_INFRA_AP_MODE;
+		bss->oper_mode = 0;
 	} else {
 		wcn36xx_warn("Unknown type for bss config: %d\n", vif->type);
 	}
@@ -1287,7 +1290,11 @@ int wcn36xx_smd_send_beacon(struct wcn36xx *wcn, struct ieee80211_vif *vif,
 	memcpy(msg_body.bssid, vif->addr, ETH_ALEN);
 
 	/* TODO need to find out why this is needed? */
-	msg_body.tim_ie_offset = tim_off+4;
+	if (vif->type == NL80211_IFTYPE_MESH_POINT)
+		/* Word around for mesh, we don't need this */
+		msg_body.tim_ie_offset = 256;
+	else
+		msg_body.tim_ie_offset = tim_off+4;
 	msg_body.p2p_ie_offset = p2p_off;
 	PREPARE_HAL_BUF(wcn->hal_buf, msg_body);
 

--- a/smd.c
+++ b/smd.c
@@ -1145,6 +1145,8 @@ int wcn36xx_smd_config_bss(struct wcn36xx *wcn, struct ieee80211_vif *vif,
 		/* Work around here to make sure beaconing happend in mesh */
 		bss->bss_type = WCN36XX_HAL_INFRA_AP_MODE;
 		bss->oper_mode = 0;
+		/* Set the self STA in bss config to support HT */
+		sta_params->ht_capable = 1;
 	} else {
 		wcn36xx_warn("Unknown type for bss config: %d\n", vif->type);
 	}


### PR DESCRIPTION
These patches enable the support of mesh mode in wcn36xx including mesh beaconing and MCS rate support.
