### PR TITLE
wcn36xx: fix coccinelle warnings

### DIFF
--- a/debug.c
+++ b/debug.c
@@ -25,13 +25,6 @@
 
 #ifdef CONFIG_WCN36XX_DEBUGFS
 
-static int wcn36xx_debugfs_open(struct inode *inode, struct file *file)
-{
-	file->private_data = inode->i_private;
-
-	return 0;
-}
-
 static ssize_t read_file_bool_bmps(struct file *file, char __user *user_buf,
 				   size_t count, loff_t *ppos)
 {
@@ -104,7 +97,7 @@ static ssize_t write_file_bool_bmps(struct file *file,
 }
 
 static const struct file_operations fops_wcn36xx_bmps = {
-	.open  =       wcn36xx_debugfs_open,
+	.open  =       simple_open,
 	.read  =       read_file_bool_bmps,
 	.write =       write_file_bool_bmps,
 };
@@ -146,7 +139,7 @@ static ssize_t write_file_dump(struct file *file,
 }
 
 static const struct file_operations fops_wcn36xx_dump = {
-	.open  =       wcn36xx_debugfs_open,
+	.open  =       simple_open,
 	.write =       write_file_dump,
 };
 


### PR DESCRIPTION
drivers/net/wireless/ath/wcn36xx/debug.c:27:11-31: WARNING opportunity for simple_open, see also structure on line 106
/c/kernel-tests/src/i386/drivers/net/wireless/ath/wcn36xx/debug.c:27:11-31: WARNING opportunity for simple_open, see also structure on line 148

 This removes an open coded simple_open() function
 and replaces file operations references to the function
 with simple_open() instead.

Generated by: coccinelle/api/simple_open.cocci

CC: Eugene Krasnikov k.eugene.e@gmail.com
CC: John W. Linville linville@tuxdriver.com
Signed-off-by: Fengguang Wu fengguang.wu@intel.com
Signed-off-by: John W. Linville linville@tuxdriver.com
