### PR TITLE
wcn36xx_msm: use KLIB_BUILD instead of KLIB

### DIFF
--- a/wcn36xx_msm/Makefile
+++ b/wcn36xx_msm/Makefile
@@ -1,7 +1,7 @@
 # make it possible to set/override android variables in .config
 -include .config
 
-CROSS_COMPILE?=$(ARM_EABI_TOOLCHAIN)/arm-eabi-
+CROSS_COMPILE ?= $(ARM_EABI_TOOLCHAIN)/arm-eabi-
 
 ifneq ($(KERNELRELEASE),)
 	wcn36xx_msm-objs		+= \
@@ -9,11 +9,12 @@ ifneq ($(KERNELRELEASE),)
 
 	obj-m := wcn36xx_msm.o
 else
-	KLIB    := $(ANDROID_PRODUCT_OUT)/obj/KERNEL_OBJ/
+	KLIB ?= $(ANDROID_PRODUCT_OUT)/obj/KERNEL_OBJ/
+	KLIB_BUILD ?= $(ANDROID_PRODUCT_OUT)/obj/KERNEL_OBJ/
 	PWD	:= $(shell pwd)
 
 default:
-	$(MAKE) ARCH=arm CROSS_COMPILE=$(CROSS_COMPILE) -C $(KLIB) SUBDIRS=$(PWD) modules
+	$(MAKE) ARCH=arm CROSS_COMPILE=$(CROSS_COMPILE) -C $(KLIB_BUILD) SUBDIRS=$(PWD) modules
 
 clean:
 	rm -rf  *.ko *.mod.* *.o .*.o.d .*.cmd .tmp_versions Module.symvers *.order \
@@ -23,6 +24,3 @@ cscope:
 	cscope -b
 
 endif
-
-
-


### PR DESCRIPTION
If not building within the kernel tree, KLIB and KLIB_BUILD can point to
different directories.  Allow for this by conditionally configuring
KLIB, and KLIB_BUILD if they haven't already been setup.
