### PR TITLE
wcn36xx: Use correct command struct for EXIT_BMPS_REQ

### DIFF
--- a/smd.c
+++ b/smd.c
@@ -1676,7 +1676,7 @@ out:
 
 int wcn36xx_smd_exit_bmps(struct wcn36xx *wcn, struct ieee80211_vif *vif)
 {
-	struct wcn36xx_hal_enter_bmps_req_msg msg_body;
+	struct wcn36xx_hal_exit_bmps_req_msg msg_body;
 	struct wcn36xx_vif *vif_priv = wcn36xx_vif_to_priv(vif);
 	int ret = 0;
 


### PR DESCRIPTION
EXIT_BMPS_REQ was using the command struct for ENTER_BMPS_REQ. I
spotted this when looking at command dumps.

Signed-off-by: Pontus Fuchs pontus.fuchs@gmail.com
